### PR TITLE
add 快捷发送列表增加一键清空该页数据

### DIFF
--- a/llcom/View/MainWindow.xaml
+++ b/llcom/View/MainWindow.xaml
@@ -266,6 +266,7 @@
                             <Button Name="QuickSendImportButton" Content="{DynamicResource QuickSendImport}" Margin="3" Click="QuickSendImportButton_Click"/>
                             <Button Name="QuickSendExportButton" Content="{DynamicResource QuickSendExport}" Grid.Column="1" Margin="3" Click="QuickSendExportButton_Click"/>
                         </Grid>
+                        <Button Name="removeAllButton" Content="{DynamicResource QuickSendRemoveAll}" Margin="3,3,3,5" Click="removeAllButton_Click"/>
                         <Button Name="importSSCOMButton" Content="{DynamicResource QuickSendImportSSCOM}" Margin="3,3,3,5" Click="ImportSSCOMButton_Click"/>
                     </StackPanel>
                 </ScrollViewer>

--- a/llcom/View/MainWindow.xaml.cs
+++ b/llcom/View/MainWindow.xaml.cs
@@ -1147,5 +1147,14 @@ namespace llcom
         {
             lastLuaChangeTime = DateTime.Now;
         }
+
+        private void removeAllButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (MessageBox.Show(TryFindResource("DeleteConfirmationMsg") as string ?? "?!", TryFindResource("DeleteConfirmation") as string ?? "?!",MessageBoxButton.YesNo,MessageBoxImage.Question) == MessageBoxResult.Yes)
+            {
+                toSendListItems.Clear();
+                SaveSendList(null, EventArgs.Empty);
+            }
+        }
     }
 }

--- a/llcom/languages/en-US.xaml
+++ b/llcom/languages/en-US.xaml
@@ -38,6 +38,9 @@
     <system:String x:Key="QuickSendTip">Lua script for data to send, also influence the data here</system:String>
     <system:String x:Key="QuickSendImport">import data to here</system:String>
     <system:String x:Key="QuickSendExport">export this page's data</system:String>
+    <system:String x:Key="QuickSendRemoveAll">clear this page's data</system:String>
+    <system:String x:Key="DeleteConfirmation">delete confirmation</system:String>
+    <system:String x:Key="DeleteConfirmationMsg">it cannot be restored after being deleted. do you want to delete it?</system:String>
     <system:String x:Key="QuickSendImportSSCOM">Import SSCOM Data</system:String>
     <system:String x:Key="QuickSendSSCOMFile">SSCOM|sscom51.ini;sscom.ini</system:String>
     <system:String x:Key="QuickSendLLCOMFile">LLCOM Quick Send List|*.lclst</system:String>

--- a/llcom/languages/zh-CN.xaml
+++ b/llcom/languages/zh-CN.xaml
@@ -38,6 +38,9 @@
     <system:String x:Key="QuickSendTip">发送处理的lua脚本，同样对此处发送的数据生效。</system:String>
     <system:String x:Key="QuickSendImport">导入数据到该页</system:String>
     <system:String x:Key="QuickSendExport">导出该页数据</system:String>
+    <system:String x:Key="QuickSendRemoveAll">一键清空该页数据</system:String>
+    <system:String x:Key="DeleteConfirmation">删除确认</system:String>
+    <system:String x:Key="DeleteConfirmationMsg">删除后不可恢复,确认删除么?</system:String>
     <system:String x:Key="QuickSendImportSSCOM">一键导入SSCOM数据</system:String>
     <system:String x:Key="QuickSendSSCOMFile">SSCOM配置文件|sscom51.ini;sscom.ini</system:String>
     <system:String x:Key="QuickSendLLCOMFile">LLCOM列表文件|*.lclst</system:String>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/13432299/180150524-9b17a6a7-5369-4f63-9bc9-5d5a392dddf4.png)


添加了很多AT指令列表

列表不够用了,将常用的列表都导出成文件

增加个一键清空该页,需要哪个时导入哪个