### PR TITLE
Create auto-response.lua

### DIFF
--- a/scripts/auto-response.lua
+++ b/scripts/auto-response.lua
@@ -1,0 +1,33 @@
+--注册串口接收函数
+uartReceive = function (data)
+    sys.publish("UART",data)--发布消息
+end
+
+--自动回复
+sys.taskInit(function()
+    while true do
+        --等待消息，超时1000ms
+        local r,udata = sys.waitUntil("UART",1000)
+        if r then
+        	local receiveHex=string.toHex(udata)
+        	log.info("收到:",receiveHex)
+        	
+        	-- 由于没有API获取快捷发送列表数量,这里写100或者更大数字,通过判断跳出
+		    for i = 1, 100 do
+		        local data = apiQuickSendList(i, false)
+		        if data and #data>0 then					
+					if data:sub(1,1) == "H" then
+						if data:find(receiveHex) then
+							local tmpData = data:gsub('H'..receiveHex..'~', '')
+							log.info("发送", apiSendUartData(tmpData:fromHex()), tmpData)
+							break
+						end
+					end
+	            else
+		            log.info("Current Complet")
+		            break
+		        end
+		    end
+        end
+    end
+end)


### PR DESCRIPTION
使用快捷发送编辑带‘~’字符的固定格式，字符可根据需要自定义调整，需要在head.lua增加方法重载，返回转换前的数据，用HEX状态做为生效和不生效的判断状态 apiQuickSendList = function (id, isTrans)
    if isTrans then 
        return apiQuickSendList(id)
    else
        return oldapiQuickSendList(id)
    end
end