### PR TITLE
在tcp client小工具中添加重连机制

### DIFF
--- a/llcom/Model/Settings.cs
+++ b/llcom/Model/Settings.cs
@@ -596,6 +596,11 @@ namespace llcom.Model
         private int _tcpServerPort = 2333;
         public int tcpServerPort { get { return _tcpServerPort; } set { _tcpServerPort = value; Save(); } }
 
+        private bool _tcpReconnect = false;
+        public bool tcpReconnect { get { return _tcpReconnect; } set { _tcpReconnect = value; Save(); } }
+        private int _tcpReconnectInterval = 5;
+        public int tcpReconnectInterval { get { return _tcpReconnectInterval; } set { _tcpReconnectInterval = value; Save(); } }
+
         private int _udpServerPort = 2333;
         public int udpServerPort { get { return _udpServerPort; } set { _udpServerPort = value; Save(); } }
 

--- a/llcom/Pages/SocketClientPage.xaml
+++ b/llcom/Pages/SocketClientPage.xaml
@@ -22,6 +22,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
@@ -87,7 +88,7 @@
                 Grid.Column="1"
                 Click="DisconnectButton_Click"
                 Content="{DynamicResource DisconnectButton}"
-                Visibility="{Binding IsConnected, Converter={StaticResource boolVisibeConverter}}" />
+                Visibility="{Binding NeedDisconnected, Converter={StaticResource boolVisibeConverter}}" />
         </Grid>
 
         <StackPanel
@@ -96,16 +97,39 @@
             Orientation="Horizontal">
             <TextBlock VerticalAlignment="Center" Text="{DynamicResource ToSendDataTextBlock}" />
             <CheckBox
-                Grid.Row="2"
                 Margin="2"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 Content="Hex"
                 IsChecked="{Binding HexMode}" />
         </StackPanel>
+        <CheckBox
+                Name="NeedReconnect"
+                Grid.Row="2"
+                Grid.ColumnSpan="3"
+                Margin="2,4,2,2"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Content="{DynamicResource TcpReconnect}"
+                IsChecked="{Binding tcpReconnect}" />
+        <StackPanel
+            Grid.Row="2"           
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
+            <TextBlock 
+                VerticalAlignment="Center"                 
+                Text="{DynamicResource TcpReconnectInterval}" />
+            <TextBox
+                    x:Name="ReconnectInterval"
+                    Text="{Binding tcpReconnectInterval, UpdateSourceTrigger=PropertyChanged}" 
+                    Width="100"
+                    VerticalAlignment="Center"
+                    IsEnabled="{Binding ElementName=NeedReconnect,Path=IsChecked}"
+                    PreviewTextInput="Reconnect_TextInputCheck" Margin="5,0,0,0"/>
+        </StackPanel>
         <TextBox
             Name="ToSendTextBox"
-            Grid.Row="2"
+            Grid.Row="3"
             Margin="0,3,0,0"
             VerticalContentAlignment="Top"
             AcceptsReturn="True"
@@ -114,7 +138,7 @@
             VerticalScrollBarVisibility="Auto" />
         <Button
             Name="SendButton"
-            Grid.Row="3"
+            Grid.Row="4"
             Margin="0,5,0,0"
             HorizontalAlignment="Right"
             Click="SendButton_Click"

--- a/llcom/Pages/SocketClientPage.xaml.cs
+++ b/llcom/Pages/SocketClientPage.xaml.cs
@@ -94,7 +94,7 @@ namespace llcom.Pages
             });
         }
 
-        private System.Timers.Timer reconnectTimer;
+        private System.Timers.Timer reconnectTimer = null;
         private void Reconnect()
         {
             if (!Changeable || IsConnected)
@@ -323,9 +323,12 @@ namespace llcom.Pages
             }
 
             NeedDisconnected = false;
-            reconnectTimer.Stop();
-            reconnectTimer.Dispose();
-            reconnectTimer = null;
+            if (reconnectTimer != null)
+            {
+                reconnectTimer.Stop();
+                reconnectTimer.Dispose();
+                reconnectTimer = null;
+            }
         }
 
         private void SendButton_Click(object sender, RoutedEventArgs e)

--- a/llcom/Pages/SocketClientPage.xaml.cs
+++ b/llcom/Pages/SocketClientPage.xaml.cs
@@ -38,6 +38,8 @@ namespace llcom.Pages
         //收到消息的事件
         public event EventHandler<byte[]> DataRecived;
         public bool IsConnected { get; set; } = false;
+        public bool NeedDisconnected { get; set; } = false;
+
         //是否可更改服务器信息
         public bool Changeable { get; set; } = true;
         public bool HexMode { get; set; } = false;
@@ -56,6 +58,8 @@ namespace llcom.Pages
             ServerTextBox.DataContext = Tools.Global.setting;
             PortTextBox.DataContext = Tools.Global.setting;
             ProtocolTypeComboBox.DataContext = Tools.Global.setting;
+            ReconnectInterval.DataContext = Tools.Global.setting;
+            NeedReconnect.DataContext = Tools.Global.setting;
 
             //收到消息显示
             DataRecived += (_, buff) =>
@@ -90,10 +94,12 @@ namespace llcom.Pages
             });
         }
 
-        private void ConnectButton_Click(object sender, RoutedEventArgs e)
+        private System.Timers.Timer reconnectTimer;
+        private void Reconnect()
         {
-            if (!Changeable)
+            if (!Changeable || IsConnected)
                 return;
+
             IPEndPoint ipe = null;
             Socket s = null;
             try
@@ -111,10 +117,10 @@ namespace llcom.Pages
                 }
                 ipe = new IPEndPoint(ip, int.Parse(PortTextBox.Text));
                 s = new Socket(ipe.AddressFamily,
-                    ProtocolTypeComboBox.SelectedIndex == 1 ? SocketType.Dgram : SocketType.Stream, 
+                    ProtocolTypeComboBox.SelectedIndex == 1 ? SocketType.Dgram : SocketType.Stream,
                     ProtocolTypeComboBox.SelectedIndex == 1 ? ProtocolType.Udp : ProtocolType.Tcp);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 ShowData($"❗ Server information error {ex.Message}");
                 Changeable = true;
@@ -133,6 +139,7 @@ namespace llcom.Pages
                         if (!so.isSSL)
                             socketNow = new SocketObj(s);
                         IsConnected = true;
+                        NeedDisconnected = true;
                         ShowData("✔ Server connected");
                     }
                     else
@@ -142,24 +149,26 @@ namespace llcom.Pages
                         return;
                     }
 
-                    if(so.isSSL)
+                    if (so.isSSL)
                     {
                         var networkStream = new NetworkStream(s);
                         var ssl = new SslStream(
                             networkStream,
                                false,
-    new RemoteCertificateValidationCallback((_, _, _, _) => true),
-    null);
+                                new RemoteCertificateValidationCallback((_, _, _, _) => true),
+                                null);
                         so.workStream = ssl;
                         try
                         {
                             ssl.AuthenticateAsClient("llcom tcp ssl client");
                         }
-                        catch(Exception ssle)
+                        catch (Exception ssle)
                         {
                             ShowData($"❗ SSL error {ssle.Message}");
                             socketNow = null;
                             IsConnected = false;
+                            if (!Tools.Global.setting.tcpReconnect)
+                                NeedDisconnected = false;
                             Changeable = true;
                             s.Close();
                             s.Dispose();
@@ -182,6 +191,37 @@ namespace llcom.Pages
                 Changeable = true;
                 return;
             }
+        }
+
+        private void ConnectButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (Tools.Global.setting.tcpReconnect)
+            {
+                reconnectTimer = new System.Timers.Timer(Tools.Global.setting.tcpReconnectInterval * 1000);
+                reconnectTimer.Elapsed += (_, _) =>
+                {
+                    if (!IsConnected)
+                    {
+                        Dispatcher.Invoke(() =>
+                        {
+                            Reconnect();
+                        });
+                    }
+                };
+                reconnectTimer.AutoReset = true;
+                reconnectTimer.Enabled = true;                
+                NeedDisconnected = true;
+            }
+            else
+            {
+                if (reconnectTimer != null)
+                {
+                    reconnectTimer.Stop();
+                    reconnectTimer.Dispose();
+                    reconnectTimer = null;
+                }
+            }
+            Reconnect();
         }
 
         public void Read_Callback(IAsyncResult ar)
@@ -214,6 +254,8 @@ namespace llcom.Pages
                         catch { }
                         socketNow = null;
                         IsConnected = false;
+                        if (!Tools.Global.setting.tcpReconnect)
+                            NeedDisconnected = false;
                         Changeable = true;
                         ShowData("❌ Server disconnected");
                     }
@@ -248,11 +290,21 @@ namespace llcom.Pages
                     catch { }
                     socketNow = null;
                     IsConnected = false;
+                    if (!Tools.Global.setting.tcpReconnect)
+                        NeedDisconnected = false;
                     Changeable = true;
                     ShowData("❌ Server disconnected");
                 }
             }
             catch { }
+        }
+
+        private void Reconnect_TextInputCheck(object sender, TextCompositionEventArgs e)
+        {
+            if (!int.TryParse(e.Text, out int num) || num < 0 || num > 120)
+            {
+                e.Handled = true;
+            }
         }
 
         private void DisconnectButton_Click(object sender, RoutedEventArgs e)
@@ -269,6 +321,11 @@ namespace llcom.Pages
                 Changeable = true;
                 ShowData("❌ Server disconnected");
             }
+
+            NeedDisconnected = false;
+            reconnectTimer.Stop();
+            reconnectTimer.Dispose();
+            reconnectTimer = null;
         }
 
         private void SendButton_Click(object sender, RoutedEventArgs e)

--- a/llcom/languages/en-US.xaml
+++ b/llcom/languages/en-US.xaml
@@ -141,6 +141,8 @@
     <system:String x:Key="CreateTcpIpv6Button">Test TCP (ipv6)</system:String>
     <system:String x:Key="DisconnectButton">Disconnect</system:String>
     <system:String x:Key="ConnectButton">Connect</system:String>
+    <system:String x:Key="TcpReconnect">Auto Reconnect</system:String>
+    <system:String x:Key="TcpReconnectInterval">Reconnect Interval:</system:String>
     <system:String x:Key="TcpServerAddr">Server address</system:String>
     <system:String x:Key="TcpServerPort">Server port</system:String>
     <system:String x:Key="TcpServerProtocol">Protocol</system:String>

--- a/llcom/languages/zh-CN.xaml
+++ b/llcom/languages/zh-CN.xaml
@@ -141,6 +141,8 @@
     <system:String x:Key="CreateTcpIpv6Button">测试TCP (ipv6)</system:String>
     <system:String x:Key="DisconnectButton">断开</system:String>
     <system:String x:Key="ConnectButton">连接</system:String>
+    <system:String x:Key="TcpReconnect">自动重连</system:String>
+    <system:String x:Key="TcpReconnectInterval">重连间隔:</system:String>
     <system:String x:Key="TcpServerAddr">服务器地址</system:String>
     <system:String x:Key="TcpServerPort">服务器端口</system:String>
     <system:String x:Key="TcpServerProtocol">协议</system:String>


### PR DESCRIPTION
测试tcp的过程中，经常有对方自动断开的情况，这里希望加一个tcp 自动重连的机制，保证tcp工具可以自动尝试重新连接而不需要用户再去点击连接按钮，连接按钮状态也跟着调整了一下。

![image](https://github.com/chenxuuu/llcom/assets/1146101/74f07357-3e8e-4507-ae7c-3b1aed080958)
