### PR TITLE
fix:在开启终端模式，输入框获取/失去焦点时会反复横跳

### DIFF
--- a/llcom/View/MainWindow.xaml
+++ b/llcom/View/MainWindow.xaml
@@ -50,8 +50,8 @@
         <Frame
             Name="dataShowFrame"
             Background="Transparent"
-            BorderBrush="#FF009400"
-            BorderThickness="0"
+            BorderBrush="#00000000"
+            BorderThickness="0.5"
             GotFocus="uartDataFlowDocument_GotFocus"
             LostFocus="uartDataFlowDocument_LostFocus"
             NavigationUIVisibility="Hidden"

--- a/llcom/View/MainWindow.xaml.cs
+++ b/llcom/View/MainWindow.xaml.cs
@@ -1342,12 +1342,12 @@ namespace llcom
         private void uartDataFlowDocument_GotFocus(object sender, RoutedEventArgs e)
         {
             if (Tools.Global.setting.terminal)
-                dataShowFrame.BorderThickness = new Thickness(0.5);
+                dataShowFrame.BorderBrush = new SolidColorBrush(Color.FromRgb(0, 148, 0));
         }
 
         private void uartDataFlowDocument_LostFocus(object sender, RoutedEventArgs e)
         {
-            dataShowFrame.BorderThickness = new Thickness(0);
+            dataShowFrame.BorderBrush = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0));
         }
 
         private void uartDataFlowDocument_PreviewTextInput(object sender, TextCompositionEventArgs e)


### PR DESCRIPTION
 #187 
让这个显示框有初始的Border 在获取/失去焦点时改变边框颜色,而不是改变边框宽度