### PR TITLE
增加新功能

### DIFF
--- a/llcom/Model/Settings.cs
+++ b/llcom/Model/Settings.cs
@@ -21,6 +21,7 @@ namespace llcom.Model
         private int _showHexFormat = 0;
         private bool _hexSend = false;
         private bool _showSend = true;
+        private bool _showSendRaw = true;
         private int _parity = 0;
         private int _timeout = 50;
         private int _dataBits = 8;
@@ -255,6 +256,19 @@ namespace llcom.Model
             set
             {
                 _showSend = value;
+                Save();
+            }
+        }
+
+        public bool showSendRaw
+        {
+            get
+            {
+                return _showSendRaw;
+            }
+            set
+            {
+                _showSendRaw = value;
                 Save();
             }
         }
@@ -603,5 +617,10 @@ namespace llcom.Model
 
         private int _udpServerPort = 2333;
         public int udpServerPort { get { return _udpServerPort; } set { _udpServerPort = value; Save(); } }
+
+        private bool _luaTestHex = false;
+        private bool _luaTestHexRev = false;
+        public bool luaTestHex { get { return _luaTestHex; } set { _luaTestHex = value; Save(); } }
+        public bool luaTestHexRev { get { return _luaTestHexRev; } set { _luaTestHexRev = value; Save(); } }
     }
 }

--- a/llcom/Model/ToSendData.cs
+++ b/llcom/Model/ToSendData.cs
@@ -1,18 +1,23 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace llcom.Model
 {
-    public class ToSendData
+    public class ToSendData : INotifyPropertyChanged
     {
         public static event EventHandler DataChanged;
+        public event PropertyChangedEventHandler PropertyChanged;
+
         private int _id;
         private string _text;
         private bool _hex;
         private string _commit;
+        private string _recvScriptPath = "";
+        private string _recvScriptPara = "";
         public int id
         {
             get
@@ -61,6 +66,29 @@ namespace llcom.Model
                 _commit = value;
                 DataChanged?.Invoke(0, EventArgs.Empty);
             }
+        }
+
+        public string recvScriptPath
+        {
+            get
+            {
+                return _recvScriptPath;
+            }
+            set
+            {
+                _recvScriptPath = value;
+                DataChanged?.Invoke(0, EventArgs.Empty);
+                OnPropertyChanged(nameof(recvScriptPath));
+            }
+        }
+
+        public string recvScriptPara {
+            get { return _recvScriptPara; }
+            set { _recvScriptPara = value; DataChanged?.Invoke(0, EventArgs.Empty); OnPropertyChanged(nameof(recvScriptPara)); } }
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/llcom/Model/Uart.cs
+++ b/llcom/Model/Uart.cs
@@ -195,13 +195,14 @@ namespace llcom.Model
         /// 发送数据
         /// </summary>
         /// <param name="data">数据内容</param>
-        public void SendData(byte[] data)
+        public void SendData(byte[] data, byte[] dataRaw = null)
         {
             if (data.Length == 0)
                 return;
             serial.Write(data, 0, data.Length);
             Tools.Global.setting.SentCount += data.Length;
-            UartDataSent(data, EventArgs.Empty);//回调
+            if(dataRaw != null && Tools.Global.setting.showSendRaw) UartDataSent(dataRaw, EventArgs.Empty);
+            if(Tools.Global.setting.showSend) UartDataSent(data, EventArgs.Empty);//回调
         }
 
         //收到串口事件的信号量

--- a/llcom/Pages/Convert.cs
+++ b/llcom/Pages/Convert.cs
@@ -14,6 +14,59 @@ namespace llcom.Pages
     }
 
     /// <summary>
+    /// bool正向设置透明度
+    /// </summary>
+    [ValueConversion(typeof(bool), typeof(float))]
+    public class boolOpacity : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (bool)value ? 1.0 : 0.25;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// 根据recvScript切换Opacity
+    /// </summary>
+    [ValueConversion(typeof(string), typeof(float))]
+    public class rsOpacity : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return string.IsNullOrEmpty(value as string) ? 0.25 : 1.0;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+            throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// 根据recvScript切换Tooltip
+    /// </summary>
+    [ValueConversion(typeof(string[]), typeof(string))]
+    public class rsTooltip : IMultiValueConverter
+    {
+        public object Convert(object[] value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string rs = value[0] as string;
+            string t = value[1] as string;
+            ResourceDictionary r = App.Current.Resources;
+            if (string.IsNullOrEmpty(rs)) return r["QuickSendRecvScriptNil"];
+            else return string.Format(r["QuickSendRecvScriptShow"] as string, rs);
+        }
+
+        object[] IMultiValueConverter.ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
     /// bool正向显示隐藏
     /// </summary>
     [ValueConversion(typeof(bool), typeof(Visibility))]

--- a/llcom/Pages/DataShowPage.xaml
+++ b/llcom/Pages/DataShowPage.xaml
@@ -182,17 +182,31 @@
                 <fa:FontAwesome
                     Name="LockIcon"
                     Icon="Lock"
+                    FontSize="16"
+                    Height="12"
                     Visibility="{Binding LockLog, Converter={StaticResource boolNotVisibeConverter}}" />
                 <fa:FontAwesome
                     Name="UnLockIcon"
                     Foreground="Green"
                     Icon="Unlock"
+                    FontSize="16"
+                    Height="12"
                     Visibility="{Binding LockLog, Converter={StaticResource boolVisibeConverter}}" />
                 <TextBlock
                     Name="UnLockText"
                     Text="{DynamicResource LockLogText}"
                     Visibility="{Binding LockLog, Converter={StaticResource boolVisibeConverter}}" />
             </StackPanel>
+        </Button>
+        <Button
+            Name="SaveLogButton"
+            Margin="0,0,18,3"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Bottom"
+            Click="SaveLogButton_Click"
+            ToolTip="{DynamicResource LockLogButton}"
+            Visibility="{Binding Path=IsMouseOver, ElementName=mainGrid, Converter={StaticResource boolVisibeConverter}}" BorderBrush="Black">
+            <fa:FontAwesome Icon="Save" HorizontalAlignment="Center" FontSize="12"/>
         </Button>
     </Grid>
 </Page>

--- a/llcom/Tools/Global.cs
+++ b/llcom/Tools/Global.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RestSharp;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -122,6 +123,7 @@ namespace llcom.Tools
         /// 是否有新版本？
         /// </summary>
         public static bool HasNewVersion { get; set; } = false;
+        public static byte[][] recvPara { get; set; } = null; // recvPara = [ uartPara, uartSendRaw ]
 
 
         /// <summary>

--- a/llcom/Tools/Logger.cs
+++ b/llcom/Tools/Logger.cs
@@ -59,7 +59,7 @@ namespace llcom.Tools
                     encoding: Encoding.UTF8,
                     rollOnFileSizeLimit: true)
                 .CreateLogger();
-            AddUartLogInfo("[SRART]Logs by LLCOM. https://github.com/chenxuuu/llcom");
+            AddUartLogInfo("[START]Logs by LLCOM. https://github.com/chenxuuu/llcom");
         }
 
         public static void CloseUartLog()
@@ -150,4 +150,5 @@ namespace llcom.Tools
         public string title;
         public SolidColorBrush color;
     }
+    class DataShowSendRaw : DataShow { }
 }

--- a/llcom/View/MainWindow.xaml
+++ b/llcom/View/MainWindow.xaml
@@ -7,6 +7,7 @@
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:llcom"
     xmlns:local_page="clr-namespace:llcom.Pages"
+    xmlns:local_tool="clr-namespace:llcom.Tools"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="{DynamicResource AppTitle}"
     Width="900"
@@ -24,6 +25,9 @@
         <RoutedUICommand x:Key="SendUartData" Text="SendUartData" />
         <local_page:boolVisibe x:Key="boolVisibeConverter" />
         <local_page:boolNotVisibe x:Key="boolNotVisibeConverter" />
+        <local_page:rsTooltip x:Key="rsToolTipConverter" />
+        <local_page:rsOpacity x:Key="rsOpacityConverter" />
+        <local_page:boolOpacity x:Key="boolOpacityConverter" />
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding
@@ -346,6 +350,8 @@
                                                 <ColumnDefinition Width="4*" />
                                                 <ColumnDefinition Width="auto" />
                                                 <ColumnDefinition Width="20" />
+                                                <ColumnDefinition Width="25" />
+                                                <ColumnDefinition Width="25" />
                                             </Grid.ColumnDefinitions>
                                             <Grid
                                                 Margin="1"
@@ -381,6 +387,57 @@
                                                 Margin="2"
                                                 HorizontalAlignment="Center"
                                                 IsChecked="{Binding hex}" />
+                                            <TextBlock
+                                                Name="recvScriptSet"
+                                                Grid.Column="4"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Opacity="{Binding recvScriptPath, Converter={StaticResource rsOpacityConverter}}"
+                                                MouseLeftButtonDown="ScriptIcon_Click"
+                                                MouseRightButtonDown="ScriptIcon_RightClick"
+                                                Tag="{Binding}">
+                                                <fa:FontAwesome Foreground="DimGray" Icon="FileText">
+                                                    <fa:FontAwesome.Style>
+                                                        <Style TargetType="fa:FontAwesome">
+                                                            <Setter Property="FontSize" Value="16"/>
+                                                            <Style.Triggers>
+                                                                <Trigger Property="IsMouseOver" Value="True">
+                                                                    <Setter Property="FontSize" Value="20"/>
+                                                                </Trigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </fa:FontAwesome.Style>
+                                                </fa:FontAwesome>
+                                                <TextBlock.ToolTip>
+                                                    <MultiBinding Converter="{StaticResource rsToolTipConverter}">
+                                                        <Binding Path="recvScriptPath" UpdateSourceTrigger="PropertyChanged"/>
+                                                        <Binding ElementName="sendDataButton" Path="Content" UpdateSourceTrigger="PropertyChanged" Delay="1000"/>
+                                                    </MultiBinding>
+                                                </TextBlock.ToolTip>
+                                            </TextBlock>
+                                            <TextBlock
+                                                Name="recvScriptPara"
+                                                Grid.Column="5"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Opacity="{Binding recvScriptPara, Converter={StaticResource rsOpacityConverter}}"
+                                                MouseLeftButtonUp="ScriptParaIcon_Click"
+                                                MouseRightButtonDown="ScriptParaIcon_RightClick"
+                                                Tag="{Binding}"
+                                                ToolTip="{DynamicResource QuickSendRecvScriptParaSet}">
+                                                <fa:FontAwesome Foreground="DimGray" Icon="Cog">
+                                                    <fa:FontAwesome.Style>
+                                                        <Style TargetType="fa:FontAwesome">
+                                                            <Setter Property="FontSize" Value="18"/>
+                                                            <Style.Triggers>
+                                                                <Trigger Property="IsMouseOver" Value="True">
+                                                                    <Setter Property="FontSize" Value="22"/>
+                                                                </Trigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </fa:FontAwesome.Style>
+                                                </fa:FontAwesome>
+                                            </TextBlock>
                                         </Grid>
                                         <ControlTemplate.Triggers>
                                             <Trigger Property="IsMouseOver" Value="true">
@@ -400,7 +457,9 @@
                             <ColumnDefinition Width="30" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="40" />
-                            <ColumnDefinition Width="auto" />
+                            <ColumnDefinition Width="22" />
+                            <ColumnDefinition Width="25" />
+                            <ColumnDefinition Width="25" />
                         </Grid.ColumnDefinitions>
                         <StackPanel
                             Name="QuickListNameStackPanel"
@@ -427,6 +486,14 @@
                             Grid.Column="3"
                             HorizontalAlignment="Center"
                             Text="{DynamicResource QuickSendHex}" />
+                        <TextBlock
+                            Grid.Column="4"
+                            HorizontalAlignment="Center"
+                            Text="{DynamicResource QuickSendRecvScript}" />
+                        <TextBlock
+                            Grid.Column="5"
+                            HorizontalAlignment="Center"
+                            Text="{DynamicResource QuickSendRecvScriptPara}" />
                     </Grid>
                     <ListBox
                         Name="toSendList"
@@ -438,6 +505,56 @@
                         VirtualizingPanel.CacheLengthUnit="Page"
                         VirtualizingPanel.IsVirtualizing="True"
                         VirtualizingPanel.VirtualizationMode="Recycling" />
+                    <Popup Name="recvScriptPopup" Placement="Bottom" VerticalOffset="5" StaysOpen="True">
+                        <ComboBox Name="recvScriptCombo" Width="250" DropDownClosed="recvScriptCombo_DropDownClosed"/>
+                    </Popup>
+                    <Popup Name="recvScriptParaPopup" Placement="Bottom" VerticalOffset="5" StaysOpen="False">
+                        <Grid Background="White">
+                            <Border BorderBrush="DarkGray" BorderThickness="1">
+                                <avalonEdit:TextEditor
+                                    xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
+                                    Name="recvScriptParaBox" 
+                                    Margin="3"
+                                    Width="250" Height="100" 
+                                    WordWrap="True"
+                                    HorizontalContentAlignment="Left"
+                                    VerticalContentAlignment="Top"
+                                    VerticalScrollBarVisibility="Visible"/>
+                            </Border>
+                            <Grid HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,1,3,0" Background="Transparent">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Name="rsParaConfirm" Grid.Column="0" Tag="{Binding ElementName=recvScriptParaBox}" MouseLeftButtonUp="ScriptParaConfirm_Click">
+                                    <fa:FontAwesome Icon="Check" Foreground="Green" FontSize="18"/>
+                                    <TextBlock.Style>
+                                        <Style TargetType="{x:Type TextBlock}">
+                                            <Setter Property="Opacity" Value="0.25"/>
+                                            <Style.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter Property="Opacity" Value="0.8"/>
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBlock Name="rsParaCancel" Grid.Column="1" MouseLeftButtonUp="ScriptParaCancel_Click">
+                                    <fa:FontAwesome Icon="Times" Foreground="Red" FontSize="18"/>
+                                    <TextBlock.Style>
+                                        <Style TargetType="{x:Type TextBlock}">
+                                            <Setter Property="Opacity" Value="0.25"/>
+                                            <Style.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter Property="Opacity" Value="0.8"/>
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Grid>
+                        </Grid>
+                    </Popup>
                     <StackPanel Grid.Row="2">
                         <Grid Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
@@ -724,7 +841,6 @@
                     Tag="en-US" />
             </MenuItem>
         </Menu>
-
 
         <!--  统计  -->
         <WebBrowser Name="TongjiWebBrowser" Visibility="Collapsed" />

--- a/llcom/View/SettingWindow.xaml
+++ b/llcom/View/SettingWindow.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:llcom"
+    xmlns:local_page="clr-namespace:llcom.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="{DynamicResource SettingTitle}"
     Width="450"
@@ -18,6 +19,9 @@
     <Window.Style>
         <Style BasedOn="{StaticResource {x:Type Window}}" TargetType="Window" />
     </Window.Style>
+    <Window.Resources>
+        <local_page:boolVisibe x:Key="boolVisibeConverter" />
+    </Window.Resources>
     <Grid>
         <TabControl>
             <TabItem Header="{DynamicResource SettingBasic}">
@@ -47,6 +51,10 @@
                             Margin="5"
                             Content="{DynamicResource SettingShowSend}"
                             IsChecked="{Binding showSend}" />
+                        <CheckBox
+                            Margin="5"
+                            Content="{DynamicResource SettingShowSendRaw}"
+                            IsChecked="{Binding showSendRaw}" />
                         <CheckBox
                             Margin="5"
                             Content="{DynamicResource SettingKeepTop}"
@@ -198,8 +206,14 @@
                         <TextBlock VerticalAlignment="Center" Text="{DynamicResource SettingLuaTestInput}" />
                         <TextBox
                             Name="luaTestTextBox"
-                            Width="150"
+                            Margin="3,0,0,0"
+                            Width="155"
                             Text="uart data" />
+                        <CheckBox
+                            Name="luaTestHexCheck"
+                            Margin="3,0,0,0"
+                            Content="HEX"
+                            IsChecked="{Binding luaTestHex}"/>
                         <Button
                             Name="luaTestbutton"
                             Margin="3,0,0,0"
@@ -315,38 +329,58 @@
                             <fa:FontAwesome Foreground="Red" Icon="Ban" />
                         </Button>
                     </WrapPanel>
-                    <WrapPanel
-                        Name="luaTestWrapPanelRev"
-                        Grid.Row="1"
-                        Margin="3"
-                        Visibility="Collapsed">
-                        <TextBlock VerticalAlignment="Center" Text="{DynamicResource SettingLuaTestInput}" />
-                        <TextBox
-                            Name="luaTestTextBoxRev"
-                            Width="150"
-                            Text="uart data" />
-                        <Button
-                            Name="luaTestbuttonRev"
-                            Margin="3,0,0,0"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Click="luaTestbuttonRev_Click"
-                            ToolTip="{DynamicResource SettingLuaTestButton}">
-                            <Grid>
-                                <fa:FontAwesome Foreground="LightBlue" Icon="PaperPlane" />
-                                <fa:FontAwesome Foreground="Black" Icon="PaperPlaneOutline" />
-                            </Grid>
-                        </Button>
-                        <Button
-                            Name="luaTestCancelbuttonRev"
-                            Margin="3,0,0,0"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Click="luaTestCancelbuttonRev_Click"
-                            ToolTip="{DynamicResource LuaCancel}">
-                            <fa:FontAwesome Foreground="Red" Icon="Ban" />
-                        </Button>
-                    </WrapPanel>
+                    <Grid Grid.Row="1" Visibility="{Binding ElementName=luaTestWrapPanelRev, Path=Visibility}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                        </Grid.RowDefinitions>
+                        <WrapPanel
+                            Name="luaTestWrapPanelRev"
+                            Grid.Row="0"
+                            Margin="3"
+                            Visibility="Collapsed">
+                            <TextBlock VerticalAlignment="Center" Text="{DynamicResource SettingLuaTestInput}" />
+                            <TextBox
+                                Name="luaTestTextBoxRev"
+                                Margin="3,0,0,0"
+                                Width="155"
+                                Text="uart data" />
+                            <CheckBox
+                                Name="luaTestHexCheckRev"
+                                Margin="3,0,0,0"
+                                Content="HEX"
+                                IsChecked="{Binding luaTestHexRev}"/>
+                            <Button
+                                Name="luaTestbuttonRev"
+                                Margin="3,0,0,0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Click="luaTestbuttonRev_Click"
+                                ToolTip="{DynamicResource SettingLuaTestButton}">
+                                <Grid>
+                                    <fa:FontAwesome Foreground="LightBlue" Icon="PaperPlane" />
+                                    <fa:FontAwesome Foreground="Black" Icon="PaperPlaneOutline" />
+                                </Grid>
+                            </Button>
+                            <Button
+                                Name="luaTestCancelbuttonRev"
+                                Margin="3,0,0,0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Click="luaTestCancelbuttonRev_Click"
+                                ToolTip="{DynamicResource LuaCancel}">
+                                <fa:FontAwesome Foreground="Red" Icon="Ban" />
+                            </Button>
+                        </WrapPanel>
+                        <WrapPanel 
+                            Grid.Row="1" 
+                            Margin="3"
+                            Orientation="Horizontal" 
+                            Visibility="{Binding ElementName=luaTestWrapPanelRev, Path=Visibility}">
+                            <TextBlock VerticalAlignment="Center" Text="{DynamicResource SettingLuaTestPara}"/>
+                            <TextBox Name="luaTestParaTextBoxRev" Margin="3,0,0,0" Width="300"/>
+                        </WrapPanel>
+                    </Grid>
                     <avalonEdit:TextEditor
                         xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
                         Name="textEditorRev"
@@ -356,7 +390,7 @@
                         LostFocus="textEditorRev_LostFocus"
                         ShowLineNumbers="True" />
                     <WrapPanel Grid.Row="3" Margin="5">
-                        <TextBlock Text="{DynamicResource SettingLuaText1}" TextWrapping="Wrap" />
+                        <TextBlock Text="{DynamicResource SettingLuaText1Recv}" TextWrapping="Wrap" />
                         <TextBlock Text="{DynamicResource SettingLuaText2Recv}" TextWrapping="Wrap" />
                         <TextBlock Text="{DynamicResource SettingLuaText3}" TextWrapping="Wrap" />
                     </WrapPanel>

--- a/llcom/View/SettingWindow.xaml.cs
+++ b/llcom/View/SettingWindow.xaml.cs
@@ -1,6 +1,7 @@
 using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.AvalonEdit.Highlighting.Xshd;
 using ICSharpCode.AvalonEdit.Search;
+using FontAwesome.WPF;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -37,6 +38,7 @@ namespace llcom
         //上次打开文件名
         private static string lastLuaFile = "";
         private static string lastLuaFileRev = "";
+
         /// <summary>
         /// 加载lua脚本文件
         /// </summary>
@@ -165,6 +167,8 @@ namespace llcom
             dataCheckComboBox.SelectedIndex = Tools.Global.setting.parity;
 
             showHexComboBox.DataContext = Tools.Global.setting;
+            //luaTestHexCheck.DataContext = Tools.Global.setting;
+            //luaTestHexCheckRev.DataContext = Tools.Global.setting;
 
             //快速搜索
             SearchPanel.Install(textEditor.TextArea);
@@ -182,8 +186,8 @@ namespace llcom
             }
             //加载上次打开的文件
             loadLuaFile(Tools.Global.setting.sendScript);
-            loadLuaFileRev(Tools.Global.setting.recvScript);
-
+            if(!string.IsNullOrEmpty(MainWindow.recvScriptBackup)) loadLuaFileRev(MainWindow.recvScriptBackup);
+            else loadLuaFileRev(Tools.Global.setting.recvScript);
             //加载编码
             var el = Encoding.GetEncodings();
             List<EncodingInfo> encodingList = new List<EncodingInfo>(el);
@@ -316,7 +320,8 @@ namespace llcom
                 {
                     byte[] r = LuaEnv.LuaLoader.Run($"{luaFileList.SelectedItem as string}.lua",
                                         new System.Collections.ArrayList{"uartData",
-                                           Tools.Global.GetEncoding().GetBytes(luaTestTextBox.Text)});
+                                            (bool)luaTestHexCheck.IsChecked ? Tools.Global.Hex2Byte(luaTestTextBox.Text) :
+                                            Tools.Global.GetEncoding().GetBytes(luaTestTextBox.Text)});
                     Tools.MessageBox.Show($"{TryFindResource("SettingLuaRunResult") as string ?? "?!"}\r\nHEX：" + Tools.Global.Byte2Hex(r) +
                         $"\r\n{TryFindResource("SettingLuaRawText") as string ?? "?!"}" + Tools.Global.Byte2Readable(r));
                 }
@@ -368,6 +373,7 @@ namespace llcom
                     saveLuaFileRev(lastLuaFileRev);
                 string fileName = luaFileListRev.SelectedItem as string;
                 loadLuaFileRev(fileName);
+                MainWindow.recvScriptBackup = fileName;
             }
         }
 
@@ -428,8 +434,11 @@ namespace llcom
                     byte[] r = LuaEnv.LuaLoader.Run(
                         $"{luaFileListRev.SelectedItem as string}.lua",
                         new System.Collections.ArrayList{
-                            "uartData",
-                            Tools.Global.GetEncoding().GetBytes(luaTestTextBoxRev.Text)
+                            "uartData", (bool)(luaTestHexCheckRev.IsChecked) ? 
+                            Tools.Global.Hex2Byte(luaTestTextBoxRev.Text) : 
+                            Tools.Global.GetEncoding().GetBytes(luaTestTextBoxRev.Text),
+                            "uartPara",
+                            Tools.Global.GetEncoding().GetBytes(luaTestParaTextBoxRev.Text)
                         },
                         "user_script_recv_convert/");
                     Tools.MessageBox.Show($"{TryFindResource("SettingLuaRunResult") as string ?? "?!"}\r\nHEX：" + Tools.Global.Byte2Hex(r) +

--- a/llcom/languages/en-US.xaml
+++ b/llcom/languages/en-US.xaml
@@ -1,4 +1,5 @@
 <ResourceDictionary
+    xml:space="preserve"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
@@ -28,12 +29,17 @@
     <system:String x:Key="QuickSendCard">Quick send</system:String>
     <system:String x:Key="QuickSendId">ID</system:String>
     <system:String x:Key="QuickSendContent">Content</system:String>
-    <system:String x:Key="QuickSendHex">HEX</system:String>
+    <system:String x:Key="QuickSendHex">Hex</system:String>
+    <system:String x:Key="QuickSendRecvScript">Rcvs</system:String>
+    <system:String x:Key="QuickSendRecvScriptPara">Para</system:String>
     <system:String x:Key="QuickSendButtonTip">Right click to change Button Content.</system:String>
     <system:String x:Key="QuickSendIdTip">Right click id to change the index of this line.</system:String>
     <system:String x:Key="QuickSendListNameTip">Right click id to change this quick send list name</system:String>
     <system:String x:Key="QuickSendListNameChangeTip">change this quick send list name</system:String>
     <system:String x:Key="QuickSendButton">Send</system:String>
+    <system:String x:Key="QuickSendRecvScriptNil">No receive script&#10;Left click to set script</system:String>
+    <system:String x:Key="QuickSendRecvScriptShow">Current receive script is: [{0}]&#10;Right click to clear the script</system:String>
+    <system:String x:Key="QuickSendRecvScriptParaSet">Left click to set script parameter&#10;Right click to clear the script parameter</system:String>
     <system:String x:Key="QuickSendAdd">Add new</system:String>
     <system:String x:Key="QuickSendRemoveLast">Remove last one</system:String>
     <system:String x:Key="QuickSendTip">Lua script for data to send, also influence the data here</system:String>
@@ -97,6 +103,7 @@
     <system:String x:Key="SettingShoText">Only Text</system:String>
     <system:String x:Key="SettingShowHexOnly">Only Hex</system:String>
     <system:String x:Key="SettingShowSend">Show data you sent</system:String>
+    <system:String x:Key="SettingShowSendRaw">Show raw data you sent</system:String>
     <system:String x:Key="SettingKeepTop">Keep Window on top</system:String>
     <system:String x:Key="SettingUartTimeout">Data pack time:</system:String>
     <system:String x:Key="SettingMs">Ms(minus means Not Pack Mode)</system:String>
@@ -124,8 +131,10 @@
     <system:String x:Key="SettingRecvLuaScript">Lua script for received data</system:String>
     <system:String x:Key="SettingLuaTestScript">Test script</system:String>
     <system:String x:Key="SettingLuaTestInput">Data to test:</system:String>
+    <system:String x:Key="SettingLuaTestPara">parameter:</system:String>
     <system:String x:Key="SettingLuaTestButton">Test data</system:String>
     <system:String x:Key="SettingLuaText1">'uartData' is received data, you can return your own result.</system:String>
+    <system:String x:Key="SettingLuaText1Recv">'uartData' is received data, you can return your own result.&#10;'uartPara' is parameter, 'uartSendRaw' is string before send script.</system:String>
     <system:String x:Key="SettingLuaText2">This script won't change your data of sent by automatic script.</system:String>
     <system:String x:Key="SettingLuaText2Recv">This script won't change your data in your own lua script which got from data receive api.</system:String>
     <system:String x:Key="SettingLuaText3">Click api reference button to see api reference.</system:String>

--- a/llcom/languages/zh-CN.xaml
+++ b/llcom/languages/zh-CN.xaml
@@ -1,4 +1,5 @@
 <ResourceDictionary
+    xml:space="preserve"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
@@ -29,11 +30,16 @@
     <system:String x:Key="QuickSendId">编号</system:String>
     <system:String x:Key="QuickSendContent">内容</system:String>
     <system:String x:Key="QuickSendHex">HEX</system:String>
+    <system:String x:Key="QuickSendRecvScript">脚本</system:String>
+    <system:String x:Key="QuickSendRecvScriptPara">参数</system:String>
     <system:String x:Key="QuickSendButtonTip">右击此按键，设置显示内容。</system:String>
     <system:String x:Key="QuickSendIdTip">右击序号，可更改改条目位置。</system:String>
     <system:String x:Key="QuickSendListNameTip">右击名称，可更改当前快捷发送列表名称。</system:String>
     <system:String x:Key="QuickSendListNameChangeTip">更改当前快捷发送列表名称</system:String>
     <system:String x:Key="QuickSendButton">发送</system:String>
+    <system:String x:Key="QuickSendRecvScriptNil">无接收脚本&#10;左击选择脚本</system:String>
+    <system:String x:Key="QuickSendRecvScriptShow">当前接收脚本为：[{0}]&#10;右击清除脚本</system:String>
+    <system:String x:Key="QuickSendRecvScriptParaSet">左击设置脚本参数&#10;右击清除脚本参数</system:String>
     <system:String x:Key="QuickSendAdd">添加新项目</system:String>
     <system:String x:Key="QuickSendRemoveLast">删除最后一项</system:String>
     <system:String x:Key="QuickSendTip">发送处理的lua脚本，同样对此处发送的数据生效。</system:String>
@@ -97,6 +103,7 @@
     <system:String x:Key="SettingShoText">只显示文本数据</system:String>
     <system:String x:Key="SettingShowHexOnly">只显示Hex数据</system:String>
     <system:String x:Key="SettingShowSend">显示串口发送出去的数据</system:String>
+    <system:String x:Key="SettingShowSendRaw">显示原始发送数据</system:String>
     <system:String x:Key="SettingKeepTop">窗口保持置顶显示</system:String>
     <system:String x:Key="SettingUartTimeout">分包数据超时时间：</system:String>
     <system:String x:Key="SettingMs">毫秒（负数为不分包模式）</system:String>
@@ -124,8 +131,10 @@
     <system:String x:Key="SettingRecvLuaScript">接收的</system:String>
     <system:String x:Key="SettingLuaTestScript">测试脚本</system:String>
     <system:String x:Key="SettingLuaTestInput">待测试的值：</system:String>
+    <system:String x:Key="SettingLuaTestPara">参数：</system:String>
     <system:String x:Key="SettingLuaTestButton">测试输入值</system:String>
     <system:String x:Key="SettingLuaText1">传入数据为uartData，传出数据为你脚本return的结果。</system:String>
+    <system:String x:Key="SettingLuaText1Recv">传入数据为uartData，传出数据为你脚本return的结果。&#10;另有参数uartPara，发送脚本处理前字符串uartSendRaw。</system:String>
     <system:String x:Key="SettingLuaText2">此处脚本对快捷发送区也生效，对脚本输出数据无效。</system:String>
     <system:String x:Key="SettingLuaText2Recv">此处脚本仅对数据显示页面有效，对脚本接收接口的数据无影响。</system:String>
     <system:String x:Key="SettingLuaText3">查看接口文档，可点击接口文档按钮。</system:String>


### PR DESCRIPTION
1. 在用ManagementObjectSearcher刷新串口列表时增加失败计数，失败三次则跳过。
2. 设置窗口中增加新CheckBox关联showSendRaw，让用户可以选择显示未经脚本处理的原始发送数据。
3. 主窗口中的日志记录窗口增加保存按钮，用以保存日志记录。
4. 测试脚本处增加CheckBox : Hex，方便进行16进制数据的测试。
5. 在快捷发送区新增设置接收脚本、设置脚本参数的图标，方便快捷发送后指定特定的接收脚本及其参数uartPara，相应的在接收脚本测试区增加了参数TextBox。
6. 新增uartSendRaw，使得接收脚本可以访问未经脚本处理的原始发送数据，该变量对快捷发送和常规发送都有效，对脚本发送无效。